### PR TITLE
build: add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/result

--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ Once installed, the `miri` command will be available. Be sure `~/.local/bin` is 
 > [!NOTE]
 > The installer script also has an uninstall option, so feel free to try it out commitment free!
 
+### Nix
+The project also provides a flake, which can be imported as follows in the flake inputs:
+```nix
+  miri = {
+    url = "github:MintyDoggo/miri";
+    inputs.nixpkgs.follows = "nixpkgs"; # optional
+    inputs.fenix.follows = "fenix"; # optional 
+    inputs.flake-utils.follows = "flake-utils"; # optional
+  };
+```
+
+The package can then be used and auto-started when niri launches, for example:
+```nix
+programs.niri = {
+  settings = {
+    spawn-at-startup = [
+      { argv = [ (lib.getExe miri.packages.${system}.default) "service" "start"]; }
+      ];
+    };
+};
+```
+
 ## Keybinds setup
 All miri actions can be spawned via `miri action <action-name>`. You can list all available actions by running `miri action`. To add an action to a keybind, edit your niri config and put the spawn command for the keybind you want
 **Example:**

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,124 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1781609335,
+        "narHash": "sha256-18sPXKaSCsA7QliUlaiH3ADArJ7Bv+8ZscW2BXJLkoE=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "dccb895d0e31771153302845c2b85699f935bd7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "fenix": [
+          "fenix"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781258734,
+        "narHash": "sha256-rfZT1gFztHDqA4gcFLO/Qv74bulhW/mXYqIHYTmc1lA=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "3ddafa67a4c7d06483995c85c66a2d285b738833",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781529264,
+        "narHash": "sha256-aRRvzyZy3zdKEFMOZTklNlkuYpk3hz6gioqN8YVV6Nw=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "888f5810a42a76a3b708b6f90e1fca8a02e3beb9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    naersk = {
+      url = "github:nix-community/naersk";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.fenix.follows = "fenix";
+    };
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      flake-utils,
+      naersk,
+      nixpkgs,
+      fenix,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = (import nixpkgs) {
+          inherit system;
+        };
+
+        withComponents = fenix.packages.${system}.complete.withComponents;
+        baseComponents = [
+          "rustc"
+          "cargo"
+          "clippy"
+        ];
+        toolchain = withComponents baseComponents;
+        devToolchain = withComponents (
+          baseComponents
+          ++ [
+            "rust-src"
+            "fmt"
+            "rust-analyzer"
+          ]
+        );
+
+        naersk' = pkgs.callPackage naersk {
+          cargo = toolchain;
+          rustc = toolchain;
+        };
+
+      in
+      {
+        # For `nix build` & `nix run`:
+        packages.default = naersk'.buildPackage {
+          src = ./.;
+        };
+
+        # For `nix develop`:
+        shells.default = pkgs.mkShell {
+          nativeBuildInputs = [
+            devToolchain
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
This PR adds a nix flake, that makes it possible to build/run the project using `nix run .#` across systems and also adds a development shell that can be entered with `nix develop`, which will enter a shell environment with a nightly toolchain installed.

In addition, miri can now be installed on NixOS systems with flakes (as shown in the docs nix section)