### PR TITLE
Restore scrolling columns when leaving master mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ maximize_single_window = true
 [scroll]
 # If true, focus stays on the current window when new windows open
 maintain_focus_on_new_window = false
+# If true, switching to scroll mode puts every tiled window in its own column
+spread_windows_on_enter = false
+# Width assigned to every column when spreading windows on entry (0-100)
+column_width_percentage = 50.0
 ```
 
 ## Misc

--- a/config.toml
+++ b/config.toml
@@ -13,3 +13,7 @@ maximize_single_window = true
 [scroll]
 # If true, focus stays on the current window when new windows open
 maintain_focus_on_new_window = false
+# If true, switching to scroll mode puts every tiled window in its own column
+spread_windows_on_enter = false
+# Width assigned to every column when spreading windows on entry (0-100)
+column_width_percentage = 50.0

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ impl MiriDefaults {
     const MASTER_WIDTH_PERCENTAGE: f64 = 50.0;
     const MASTER_MAXIMIZE_SINGLE_WINDOW: bool = true;
     const SCROLL_MAINTAIN_FOCUS_ON_NEW_WINDOW: bool = false;
+    const SCROLL_SPREAD_WINDOWS_ON_ENTER: bool = false;
+    const SCROLL_COLUMN_WIDTH_PERCENTAGE: f64 = 50.0;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -48,12 +50,16 @@ impl Default for MasterConfig {
 #[serde(default)]
 pub struct ScrollConfig {
     pub maintain_focus_on_new_window: bool,
+    pub spread_windows_on_enter: bool,
+    pub column_width_percentage: f64,
 }
 
 impl Default for ScrollConfig {
     fn default() -> Self {
         Self {
             maintain_focus_on_new_window: MiriDefaults::SCROLL_MAINTAIN_FOCUS_ON_NEW_WINDOW,
+            spread_windows_on_enter: MiriDefaults::SCROLL_SPREAD_WINDOWS_ON_ENTER,
+            column_width_percentage: MiriDefaults::SCROLL_COLUMN_WIDTH_PERCENTAGE,
         }
     }
 }

--- a/src/layout/handler.rs
+++ b/src/layout/handler.rs
@@ -1,4 +1,5 @@
 use niri_ipc::{Action, Request, SizeChange, Window, socket::Socket};
+use std::collections::BTreeMap;
 
 use crate::{
     config::MiriConfig,
@@ -6,6 +7,91 @@ use crate::{
     layout::master::{handle_master_gain_window, handle_master_lose_window},
     service_state::{MiriWindow, MiriWorkspace},
 };
+
+#[derive(Debug, PartialEq)]
+struct ScrollLayoutPlan {
+    columns: BTreeMap<usize, Vec<(usize, u64)>>,
+    window_ids: Vec<u64>,
+    focused_window_id: Option<u64>,
+}
+
+fn plan_scroll_layout(windows: &[&Window]) -> ScrollLayoutPlan {
+    let mut columns: BTreeMap<usize, Vec<(usize, u64)>> = BTreeMap::new();
+    let mut window_ids = Vec::new();
+    let mut focused_window_id = None;
+
+    for window in windows {
+        if window.is_floating {
+            continue;
+        }
+        let Some((column, row)) = window.layout.pos_in_scrolling_layout else {
+            continue;
+        };
+
+        columns.entry(column).or_default().push((row, window.id));
+        window_ids.push(window.id);
+        if window.is_focused {
+            focused_window_id = Some(window.id);
+        }
+    }
+
+    for windows_in_column in columns.values_mut() {
+        windows_in_column.sort_unstable_by_key(|(row, _)| *row);
+    }
+
+    ScrollLayoutPlan {
+        columns,
+        window_ids,
+        focused_window_id,
+    }
+}
+
+fn force_scroll_layout(windows: Vec<&Window>, socket: &mut Socket, config: &MiriConfig) {
+    if !config.scroll.spread_windows_on_enter {
+        return;
+    }
+
+    let plan = plan_scroll_layout(&windows);
+
+    // Expel bottom windows one at a time. Re-focus the top window before each
+    // action because niri focuses the window it just expelled.
+    for windows_in_column in plan.columns.values() {
+        if let Some((_, anchor_window_id)) = windows_in_column.first().copied() {
+            for _ in 1..windows_in_column.len() {
+                socket
+                    .send(Request::Action(Action::FocusWindow { id: anchor_window_id }))
+                    .expect("lost connection to niri")
+                    .expect("niri rejected FocusWindow while spreading scroll columns");
+                socket
+                    .send(Request::Action(Action::ExpelWindowFromColumn {}))
+                    .expect("lost connection to niri")
+                    .expect("niri rejected ExpelWindowFromColumn");
+            }
+        }
+    }
+
+    // Every tiled window is now its own full-height scrolling column.
+    for window_id in plan.window_ids {
+        socket
+            .send(Request::Action(Action::SetWindowWidth {
+                id: Some(window_id),
+                change: SizeChange::SetProportion(config.scroll.column_width_percentage),
+            }))
+            .expect("lost connection to niri")
+            .expect("niri rejected SetWindowWidth for scroll column");
+        socket
+            .send(Request::Action(Action::ResetWindowHeight { id: Some(window_id) }))
+            .expect("lost connection to niri")
+            .expect("niri rejected ResetWindowHeight for scroll window");
+    }
+
+    if let Some(id) = plan.focused_window_id {
+        socket
+            .send(Request::Action(Action::FocusWindow { id }))
+            .expect("lost connection to niri")
+            .expect("niri rejected FocusWindow while restoring focus");
+    }
+}
 
 pub fn handle_workspace_gain_window(
     current_workspace: &MiriWorkspace,
@@ -117,6 +203,50 @@ pub fn force_workspace_windows_into_layout_mode(
                 .expect("lost connection to niri")
                 .expect("niri rejected FocusColumnLeft");
         }
-        Mode::Scroll => {}
+        Mode::Scroll => force_scroll_layout(windows, socket, config),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use niri_ipc::WindowLayout;
+
+    use super::*;
+
+    fn window(id: u64, position: Option<(usize, usize)>, is_focused: bool, is_floating: bool) -> Window {
+        Window {
+            id,
+            title: None,
+            app_id: None,
+            pid: None,
+            workspace_id: Some(1),
+            is_focused,
+            is_floating,
+            is_urgent: false,
+            layout: WindowLayout {
+                pos_in_scrolling_layout: position,
+                tile_size: (0.0, 0.0),
+                window_size: (0, 0),
+                tile_pos_in_workspace_view: None,
+                window_offset_in_tile: (0.0, 0.0),
+            },
+            focus_timestamp: None,
+        }
+    }
+
+    #[test]
+    fn plans_tiled_windows_by_column_and_preserves_focus() {
+        let top = window(10, Some((2, 1)), false, false);
+        let bottom = window(11, Some((2, 2)), true, false);
+        let first = window(12, Some((1, 1)), false, false);
+        let floating = window(13, None, false, true);
+        let windows = vec![&bottom, &floating, &first, &top];
+
+        let plan = plan_scroll_layout(&windows);
+
+        assert_eq!(plan.columns.get(&1), Some(&vec![(1, 12)]));
+        assert_eq!(plan.columns.get(&2), Some(&vec![(1, 10), (2, 11)]));
+        assert_eq!(plan.window_ids, vec![11, 12, 10]);
+        assert_eq!(plan.focused_window_id, Some(11));
     }
 }

--- a/src/layout/handler.rs
+++ b/src/layout/handler.rs
@@ -8,19 +8,10 @@ use crate::{
     service_state::{MiriWindow, MiriWorkspace},
 };
 
-#[derive(Debug, PartialEq)]
-struct ScrollLayoutPlan {
-    columns: BTreeMap<usize, Vec<(usize, u64)>>,
-    window_ids: Vec<u64>,
-    focused_window_id: Option<u64>,
-}
-
-fn plan_scroll_layout(windows: &[&Window]) -> ScrollLayoutPlan {
+fn group_workspace_windows_by_column(workspace_windows: &[&Window]) -> BTreeMap<usize, Vec<(usize, u64)>> {
     let mut columns: BTreeMap<usize, Vec<(usize, u64)>> = BTreeMap::new();
-    let mut window_ids = Vec::new();
-    let mut focused_window_id = None;
 
-    for window in windows {
+    for window in workspace_windows {
         if window.is_floating {
             continue;
         }
@@ -29,39 +20,33 @@ fn plan_scroll_layout(windows: &[&Window]) -> ScrollLayoutPlan {
         };
 
         columns.entry(column).or_default().push((row, window.id));
-        window_ids.push(window.id);
-        if window.is_focused {
-            focused_window_id = Some(window.id);
-        }
     }
 
     for windows_in_column in columns.values_mut() {
         windows_in_column.sort_unstable_by_key(|(row, _)| *row);
     }
 
-    ScrollLayoutPlan {
-        columns,
-        window_ids,
-        focused_window_id,
-    }
+    columns
 }
 
-fn force_scroll_layout(windows: Vec<&Window>, socket: &mut Socket, config: &MiriConfig) {
-    if !config.scroll.spread_windows_on_enter {
-        return;
-    }
+fn force_scroll_layout(workspace_windows: Vec<&Window>, socket: &mut Socket, column_width_percentage: f64) {
+    let focused_window_id = workspace_windows
+        .iter()
+        .find(|window| window.is_focused)
+        .map(|window| window.id);
+    let grouped_windows = group_workspace_windows_by_column(&workspace_windows);
 
-    let plan = plan_scroll_layout(&windows);
-
-    // Expel bottom windows one at a time. Re-focus the top window before each
-    // action because niri focuses the window it just expelled.
-    for windows_in_column in plan.columns.values() {
+    // Expel bottom windows one at a time from each original column.
+    for windows_in_column in grouped_windows.values() {
         if let Some((_, anchor_window_id)) = windows_in_column.first().copied() {
+            if windows_in_column.len() == 1 {
+                continue;
+            }
+            socket
+                .send(Request::Action(Action::FocusWindow { id: anchor_window_id }))
+                .expect("lost connection to niri")
+                .expect("niri rejected FocusWindow while spreading scroll columns");
             for _ in 1..windows_in_column.len() {
-                socket
-                    .send(Request::Action(Action::FocusWindow { id: anchor_window_id }))
-                    .expect("lost connection to niri")
-                    .expect("niri rejected FocusWindow while spreading scroll columns");
                 socket
                     .send(Request::Action(Action::ExpelWindowFromColumn {}))
                     .expect("lost connection to niri")
@@ -71,21 +56,24 @@ fn force_scroll_layout(windows: Vec<&Window>, socket: &mut Socket, config: &Miri
     }
 
     // Every tiled window is now its own full-height scrolling column.
-    for window_id in plan.window_ids {
+    for window in workspace_windows
+        .into_iter()
+        .filter(|window| !window.is_floating && window.layout.pos_in_scrolling_layout.is_some())
+    {
         socket
             .send(Request::Action(Action::SetWindowWidth {
-                id: Some(window_id),
-                change: SizeChange::SetProportion(config.scroll.column_width_percentage),
+                id: Some(window.id),
+                change: SizeChange::SetProportion(column_width_percentage),
             }))
             .expect("lost connection to niri")
             .expect("niri rejected SetWindowWidth for scroll column");
         socket
-            .send(Request::Action(Action::ResetWindowHeight { id: Some(window_id) }))
+            .send(Request::Action(Action::ResetWindowHeight { id: Some(window.id) }))
             .expect("lost connection to niri")
             .expect("niri rejected ResetWindowHeight for scroll window");
     }
 
-    if let Some(id) = plan.focused_window_id {
+    if let Some(id) = focused_window_id {
         socket
             .send(Request::Action(Action::FocusWindow { id }))
             .expect("lost connection to niri")
@@ -203,7 +191,11 @@ pub fn force_workspace_windows_into_layout_mode(
                 .expect("lost connection to niri")
                 .expect("niri rejected FocusColumnLeft");
         }
-        Mode::Scroll => force_scroll_layout(windows, socket, config),
+        Mode::Scroll => {
+            if config.scroll.spread_windows_on_enter {
+                force_scroll_layout(windows, socket, config.scroll.column_width_percentage);
+            }
+        }
     }
 }
 
@@ -235,18 +227,16 @@ mod tests {
     }
 
     #[test]
-    fn plans_tiled_windows_by_column_and_preserves_focus() {
+    fn groups_tiled_workspace_windows_by_column() {
         let top = window(10, Some((2, 1)), false, false);
         let bottom = window(11, Some((2, 2)), true, false);
         let first = window(12, Some((1, 1)), false, false);
         let floating = window(13, None, false, true);
         let windows = vec![&bottom, &floating, &first, &top];
 
-        let plan = plan_scroll_layout(&windows);
+        let grouped_windows = group_workspace_windows_by_column(&windows);
 
-        assert_eq!(plan.columns.get(&1), Some(&vec![(1, 12)]));
-        assert_eq!(plan.columns.get(&2), Some(&vec![(1, 10), (2, 11)]));
-        assert_eq!(plan.window_ids, vec![11, 12, 10]);
-        assert_eq!(plan.focused_window_id, Some(11));
+        assert_eq!(grouped_windows.get(&1), Some(&vec![(1, 12)]));
+        assert_eq!(grouped_windows.get(&2), Some(&vec![(1, 10), (2, 11)]));
     }
 }


### PR DESCRIPTION
## Summary

When switching from master mode back to scroll mode, optionally split tiled windows into individual scrolling columns. Restore the previously focused window and apply a configurable width to each column.

Previously, entering scroll mode did not change the layout, leaving the stacked master column in place.

The behavior is disabled by default and can be enabled with:

```toml
[scroll]
spread_windows_on_enter = true
column_width_percentage = 50.0
```

## Testing

- `cargo fmt -- --check`
- `cargo test`
- `cargo build --release`
- Tested locally with niri 26.04

https://github.com/user-attachments/assets/1d2fbb71-3645-4bea-a862-af455befe034


